### PR TITLE
[JENKINS-49130] - Stop persisting Sonar requester context on the disk to make the plugin compatible with Jenkins 2.102+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <url>https://github.com/arkanjoms/sonar-quality-gates-plugin/blob/master/README.md</url>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.level>8</java.level>
         <jenkins.version>2.60.3</jenkins.version>
     </properties>
 
@@ -93,15 +93,6 @@
             <version>2.8.0</version>
         </dependency>
 
-        <!--Test-->
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-war</artifactId>
-            <type>war</type>
-            <version>${jenkins.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
@@ -150,27 +141,19 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/src/main/java/org/quality/gates/sonar/api5x/SonarHttpRequester5x.java
+++ b/src/main/java/org/quality/gates/sonar/api5x/SonarHttpRequester5x.java
@@ -1,7 +1,5 @@
 package org.quality.gates.sonar.api5x;
 
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.quality.gates.jenkins.plugin.GlobalConfigDataForSonarInstance;
 import org.quality.gates.jenkins.plugin.JobConfigData;
 import org.quality.gates.sonar.api.SonarHttpRequester;

--- a/src/main/java/org/quality/gates/sonar/api60/SonarHttpRequester60.java
+++ b/src/main/java/org/quality/gates/sonar/api60/SonarHttpRequester60.java
@@ -1,7 +1,5 @@
 package org.quality.gates.sonar.api60;
 
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.quality.gates.jenkins.plugin.GlobalConfigDataForSonarInstance;
 import org.quality.gates.jenkins.plugin.JobConfigData;
 import org.quality.gates.sonar.api.SonarHttpRequester;

--- a/src/main/java/org/quality/gates/sonar/api61/SonarHttpRequester61.java
+++ b/src/main/java/org/quality/gates/sonar/api61/SonarHttpRequester61.java
@@ -1,7 +1,5 @@
 package org.quality.gates.sonar.api61;
 
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.quality.gates.jenkins.plugin.GlobalConfigDataForSonarInstance;
 import org.quality.gates.jenkins.plugin.JobConfigData;
 import org.quality.gates.sonar.api.SonarHttpRequester;


### PR DESCRIPTION
Both QGPublisher and QGBuilder store service classes which include `SonarHttpRequester` implementations. This class implements lazy login, but the fields are not marked as transient and hence they were serialized to the disk in some cases. Such behavior is not compatible with Jenkins 2.102+, which rejects serialization of non-whitelisted classes (see [JEP-200](https://github.com/jenkinsci/jep/tree/master/jep/200)). 

This pull request makes the cache fields transient. I cannot fully test the plugins, so maybe it's not enough to get the plugin running.

https://issues.jenkins-ci.org/browse/JENKINS-49130

@reviewbybees @jglick 
