### PR TITLE
Update SonarHttpRequester.java

### DIFF
--- a/src/main/java/org/quality/gates/sonar/api/SonarHttpRequester.java
+++ b/src/main/java/org/quality/gates/sonar/api/SonarHttpRequester.java
@@ -37,7 +37,7 @@ public abstract class SonarHttpRequester {
 
     private static Logger LOGGER = LoggerFactory.getLogger(SonarHttpRequester.class);
 
-    private static final String SONAR_API_COMPONENT_SHOW = "/api/components/show?key=%s";
+    private static final String SONAR_API_COMPONENT_SHOW = "/api/components/show?component=%s";
 
     /**
      * Cached client context for lazy login.


### PR DESCRIPTION
the api is not backward compatible with sonar 8.0, and cause a failure, need to use parameter "component" instead of "key"