### PR TITLE
Update QGPublisher.java

### DIFF
--- a/src/main/java/org/quality/gates/jenkins/plugin/QGPublisher.java
+++ b/src/main/java/org/quality/gates/jenkins/plugin/QGPublisher.java
@@ -72,7 +72,7 @@ public class QGPublisher extends Recorder {
 
         Result result = build.getResult();
 
-        if (Result.SUCCESS != result) {
+        if (Result.SUCCESS != result && Result.UNSTABLE != result) {
             listener.getLogger().println("Previous steps failed the build.\nResult is: " + result);
 
             return false;


### PR DESCRIPTION
The build will no longer become failed if any previous plugin changed the build result to "Unstable".
I had the issue when some plugin changed the build result to "Unstable" and then "Sonar quality gates plugin" changed the build result to "Failed" even if quality gates was successful.