### PR TITLE
Fix SECURITY-1523 / CVE-2020-2150

### DIFF
--- a/src/main/java/org/quality/gates/jenkins/plugin/GlobalConfigDataForSonarInstance.java
+++ b/src/main/java/org/quality/gates/jenkins/plugin/GlobalConfigDataForSonarInstance.java
@@ -80,8 +80,8 @@ public class GlobalConfigDataForSonarInstance {
         this.username = username;
     }
 
-    public String getPass() {
-        return Secret.toString(secretPass);
+    public Secret getPass() {
+        return secretPass != null ? secretPass : Secret.fromString("");
     }
 
     public void setPass(String pass) {

--- a/src/main/java/org/quality/gates/sonar/api/SonarHttpRequester.java
+++ b/src/main/java/org/quality/gates/sonar/api/SonarHttpRequester.java
@@ -83,7 +83,7 @@ public abstract class SonarHttpRequester {
                     AuthScope.ANY,
                     new UsernamePasswordCredentials(
                             globalConfigDataForSonarInstance.getUsername(),
-                            globalConfigDataForSonarInstance.getPass()));
+                            globalConfigDataForSonarInstance.getPass().getPlainText()));
 
             httpClient = HttpClientBuilder.create()
                     .setDefaultCredentialsProvider(credsProvider)
@@ -95,7 +95,8 @@ public abstract class SonarHttpRequester {
 
             List<NameValuePair> nvps = new ArrayList<>();
             nvps.add(new BasicNameValuePair("login", globalConfigDataForSonarInstance.getUsername()));
-            nvps.add(new BasicNameValuePair("password", globalConfigDataForSonarInstance.getPass()));
+            nvps.add(new BasicNameValuePair(
+                    "password", globalConfigDataForSonarInstance.getPass().getPlainText()));
             nvps.add(new BasicNameValuePair("remember_me", "1"));
             loginHttpPost.setEntity(createEntity(nvps));
             loginHttpPost.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");

--- a/src/main/java/org/quality/gates/sonar/api/SonarInstanceValidationService.java
+++ b/src/main/java/org/quality/gates/sonar/api/SonarInstanceValidationService.java
@@ -37,15 +37,15 @@ public class SonarInstanceValidationService {
 
     private Secret validatePassword(GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) {
 
-        String sonarPassword;
+        Secret sonarPassword;
 
-        if (globalConfigDataForSonarInstance.getPass().isEmpty()) {
-            sonarPassword = GlobalConfigDataForSonarInstance.DEFAULT_PASS;
+        if (globalConfigDataForSonarInstance.getPass().getPlainText().isEmpty()) {
+            sonarPassword = Secret.fromString(GlobalConfigDataForSonarInstance.DEFAULT_PASS);
         } else {
             sonarPassword = globalConfigDataForSonarInstance.getPass();
         }
 
-        return Secret.fromString(sonarPassword);
+        return sonarPassword;
     }
 
     GlobalConfigDataForSonarInstance validateData(GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) {

--- a/src/test/java/org/quality/gates/jenkins/plugin/BuildDecisionTest.java
+++ b/src/test/java/org/quality/gates/jenkins/plugin/BuildDecisionTest.java
@@ -97,7 +97,7 @@ public class BuildDecisionTest {
         GlobalConfigDataForSonarInstance returnedInstance =
                 buildDecision.chooseSonarInstance(globalConfig, jobConfigData);
         assertTrue(returnedInstance.getName().equals(emptyString));
-        assertTrue(returnedInstance.getPass().equals(emptyString));
+        assertTrue(returnedInstance.getPass().getPlainText().equals(emptyString));
         assertTrue(returnedInstance.getSonarUrl().equals(emptyString));
         assertTrue(returnedInstance.getUsername().equals(emptyString));
     }


### PR DESCRIPTION
Use Secret instead of Sting in getPass() method

In response to the 2020 security advisory, it was noted that passwords were sent in plain text when loading the global config form in Jenkins 2.204.3. This issue was resolved starting from Jenkins 2.236, where f:password values are now always round-tripped in their encrypted form. Therefore, the behavior observed in the 2020 advisory no longer applies to more recent Jenkins releases.

The suggestion to switch types around remains valid as it prevents constant re-encryption of plaintext values, i believe this PR addresses this, the password is stored and transmitted as a Secret, and masked on the UI.

Conversation related to this matter can be found here:
https://groups.google.com/g/jenkinsci-dev/c/Qh8oJo1iYFk

### Submitter checklist
- [X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [X ] Please describe what you did