### PR TITLE
Fix sonar instance global config

### DIFF
--- a/src/main/java/org/quality/gates/jenkins/plugin/GlobalSonarQualityGatesConfiguration.java
+++ b/src/main/java/org/quality/gates/jenkins/plugin/GlobalSonarQualityGatesConfiguration.java
@@ -46,7 +46,6 @@ public class GlobalSonarQualityGatesConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
         sonarInstances = globalConfigurationService.instantiateGlobalConfigData(json);
-        req.bindJSON(this, json);
         save();
 
         return true;

--- a/src/main/java/org/quality/gates/jenkins/plugin/SonarInstance.java
+++ b/src/main/java/org/quality/gates/jenkins/plugin/SonarInstance.java
@@ -83,7 +83,7 @@ public class SonarInstance extends AbstractDescribableImpl<SonarInstance> {
     }
 
     public Secret getPass() {
-        return secretPass != null ? secretPass : Secret.fromString("");
+        return secretPass;
     }
 
     @DataBoundSetter
@@ -119,7 +119,7 @@ public class SonarInstance extends AbstractDescribableImpl<SonarInstance> {
     }
 
     public Secret getToken() {
-        return token != null ? token : Secret.fromString("");
+        return token;
     }
 
     @DataBoundSetter

--- a/src/test/java/org/quality/gates/jenkins/plugin/BuildDecisionTest.java
+++ b/src/test/java/org/quality/gates/jenkins/plugin/BuildDecisionTest.java
@@ -1,6 +1,7 @@
 package org.quality.gates.jenkins.plugin;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -90,7 +91,7 @@ public class BuildDecisionTest {
         doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchSonarInstances();
         SonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, jobConfigData);
         assertTrue(returnedInstance.getName().equals(emptyString));
-        assertTrue(returnedInstance.getPass().getPlainText().equals(emptyString));
+        assertNull(returnedInstance.getPass());
         assertTrue(returnedInstance.getUrl().equals(emptyString));
         assertTrue(returnedInstance.getUsername().equals(emptyString));
     }


### PR DESCRIPTION
Previously, when loading the Jenkins configuration, an empty Secret was created for token if the user had initially configured their SonarInstance with a username and password instead. This caused unintended behavior in addGlobalConfigDataForSonarInstance(), leading to incorrect authentication logic.

### Testing done

mvn clean verify and manual testing config in UI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
