### PR TITLE
[JENKINS-75326] Improve api logging and fix issue caused by httpclient update

### DIFF
--- a/src/main/java/org/quality/gates/sonar/api/ApiConnectionException.java
+++ b/src/main/java/org/quality/gates/sonar/api/ApiConnectionException.java
@@ -6,7 +6,7 @@ package org.quality.gates.sonar.api;
  */
 public class ApiConnectionException extends RuntimeException {
 
-    public ApiConnectionException(String message) {
-        super(message);
+    public ApiConnectionException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/org/quality/gates/sonar/api/SonarHttpRequesterFactory.java
+++ b/src/main/java/org/quality/gates/sonar/api/SonarHttpRequesterFactory.java
@@ -3,8 +3,6 @@ package org.quality.gates.sonar.api;
 import java.io.IOException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
-import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.quality.gates.jenkins.plugin.SonarInstance;
 import org.quality.gates.sonar.api80.SonarHttpRequester80;
@@ -20,11 +18,9 @@ class SonarHttpRequesterFactory {
 
     static SonarHttpRequester getSonarHttpRequester(SonarInstance sonarInstance) {
         var request = new HttpGet(getSonarApiServerVersion(sonarInstance));
-        var context = HttpClientContext.create();
-
-        try (var client = HttpClientBuilder.create().build();
-                var response = client.execute(request, context, classicHttpResponse -> classicHttpResponse)) {
-            var sonarVersion = EntityUtils.toString(response.getEntity());
+        try (var client = HttpClientBuilder.create().build()) {
+            var sonarVersion = client.execute(
+                    request, classicHttpResponse -> EntityUtils.toString(classicHttpResponse.getEntity()));
 
             if (majorSonarVersion(sonarVersion) == 8 && minorSonarVersion(sonarVersion) <= 7) {
                 return new SonarHttpRequester80();
@@ -33,7 +29,7 @@ class SonarHttpRequesterFactory {
             } else {
                 throw new UnsuportedVersionException("Plugin doesn't support this version of sonar api!");
             }
-        } catch (IOException | ParseException e) {
+        } catch (IOException e) {
             throw new ApiConnectionException(e.getLocalizedMessage(), e);
         }
     }

--- a/src/main/java/org/quality/gates/sonar/api/SonarHttpRequesterFactory.java
+++ b/src/main/java/org/quality/gates/sonar/api/SonarHttpRequesterFactory.java
@@ -34,7 +34,7 @@ class SonarHttpRequesterFactory {
                 throw new UnsuportedVersionException("Plugin doesn't support this version of sonar api!");
             }
         } catch (IOException | ParseException e) {
-            throw new ApiConnectionException(e.getLocalizedMessage(),e);
+            throw new ApiConnectionException(e.getLocalizedMessage(), e);
         }
     }
 

--- a/src/main/java/org/quality/gates/sonar/api/SonarHttpRequesterFactory.java
+++ b/src/main/java/org/quality/gates/sonar/api/SonarHttpRequesterFactory.java
@@ -34,7 +34,7 @@ class SonarHttpRequesterFactory {
                 throw new UnsuportedVersionException("Plugin doesn't support this version of sonar api!");
             }
         } catch (IOException | ParseException e) {
-            throw new ApiConnectionException(e.getLocalizedMessage());
+            throw new ApiConnectionException(e.getLocalizedMessage(),e);
         }
     }
 


### PR DESCRIPTION
### Summary
The Pullrequest is designed to improve traceability of connectivity issues in the Jenkins Log when connectivity issues arise.
Currently I'm having Issues with connecting my Jenkins Installation for this Plugin with my Sonarqube installation. This change is designed to provide more technical detail information when respective ApiConnectionExceptions occur at runtime. This is meant to transport the root cause to the Jenkins log.

### Testing 
I'm not sure how to explicitly test this change in the context of expected Exceptions.

### Jira Issue
[JENKINS-75326](https://issues.jenkins.io/browse/JENKINS-75326)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

### Addendum - Root Cause

The proposed logging improvement was tested on a local Jenkins installation - the additional Root Cause Stacktrace logging for ApiConnectionExceptions revealed the actual issue with the Http Client 5 integration and its consuming behavior for HttpResponse.getEntity information.

The Pull request addresses the correct integration of the HttpClient5 library by consuming the Sonar HttpResponses within respective handler method closures  instead of trying to consume an unaltered `ClassicHttpResponse` object by having the handler return it unaltered. The HttpClients execute method marks the `ClassicHttpResponse.getEntity` object as consumed after it executed the provided `ResponseHandler`, so the original HttpClient5 plugin processing logic could not have worked correctly as it would always have operated on an already consumed `ClassicHttpResponse.getEntity()` object.

**The Pullrequests therefore contains the initially proposed root cause transport to Jenkins logging system as well as an update on the HttpClient5 integration**


